### PR TITLE
Fix Node example

### DIFF
--- a/example/node-site/package.json
+++ b/example/node-site/package.json
@@ -2,10 +2,13 @@
   "name": "node-server-example",
   "version": "0.0.0",
   "scripts": {
-    "serve": "node index.js"
+    "serve": "node -r esm index.js"
   },
   "dependencies": {
     "express": "^4.17.1",
     "node-fetch": "^2.6.1"
+  },
+  "devDependencies": {
+    "esm": "^3.2.25"
   }
 }

--- a/example/node-site/yarn.lock
+++ b/example/node-site/yarn.lock
@@ -90,6 +90,11 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
+esm@^3.2.25:
+  version "3.2.25"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.25.tgz#342c18c29d56157688ba5ce31f8431fbb795cc10"
+  integrity sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==
+
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"


### PR DESCRIPTION
@tbgse Perhaps this could be useful for supporting Netlify functions.

This example works using Express.js. The only problem is that, in order to run it, we need to remove `example/package.json#type=module` until better ESM support is added in Vite.
