### PR TITLE
Error handling and redirects

### DIFF
--- a/examples/react/yarn.lock
+++ b/examples/react/yarn.lock
@@ -549,11 +549,6 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-esbuild@^0.11.6:
-  version "0.11.6"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.6.tgz#20961309c4cfed00b71027e18806150358d0cbb0"
-  integrity sha512-L+nKW9ftVS/N2CVJMR9YmXHbkm+vHzlNYuo09rzipQhF7dYNvRLfWoEPSDRTl10and4owFBV9rJ2CTFNtLIOiw==
-
 esbuild@^0.9.3:
   version "0.9.7"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.9.7.tgz#ea0d639cbe4b88ec25fbed4d6ff00c8d788ef70b"
@@ -1189,10 +1184,10 @@ value-equal@^1.0.1:
   resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
   integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
-vite-ssr@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/vite-ssr/-/vite-ssr-0.7.1.tgz#34e97eafd4ff008a8d072ddf64c6dc381fcca6bb"
-  integrity sha512-9stCJ8/79UOn18PjFhhoVNhICqRyriBFJPHc1BAxyLjGcN//xjdk0Pc0pxztr2gEPSh2dn1gDsDVBbdUJ6YubQ==
+vite-ssr@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/vite-ssr/-/vite-ssr-0.8.0.tgz#1c45b5c1e3321c827eee38e22ce46ee9c715dcf1"
+  integrity sha512-ALJQLGWEAhqryALUCLQo5TXRgnWy1q/zPeRT5MFBcxeND84ReJ0Z+GEl4jHh0N02hPvdZghJh3Jtkuv8RxbWKQ==
   dependencies:
     "@rollup/plugin-replace" "^2.3.3"
     "@vue/server-renderer" "^3.0.0"
@@ -1213,7 +1208,7 @@ vite@^2.1.5:
     fsevents "~2.3.1"
 
 "vitedge@file:../../src":
-  version "0.10.3"
+  version "0.10.5"
   dependencies:
     "@cloudflare/kv-asset-handler" "^0.1.1"
     "@rollup/plugin-commonjs" "^18.0.0"
@@ -1221,13 +1216,13 @@ vite@^2.1.5:
     "@rollup/plugin-node-resolve" "^11.2.1"
     "@rollup/plugin-replace" "^2.4.2"
     "@rollup/plugin-virtual" "^2.0.3"
-    esbuild "^0.11.6"
+    esbuild "^0.9.3"
     fast-glob "^3.2.5"
     multienv-loader "^1.2.0"
     node-fetch "^2.6.1"
     rollup "^2.44.0"
     rollup-plugin-esbuild "^3.0.2"
-    vite-ssr "0.7.1"
+    vite-ssr "0.8.0"
 
 wrappy@1:
   version "1.0.2"

--- a/examples/vue/yarn.lock
+++ b/examples/vue/yarn.lock
@@ -855,15 +855,15 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-esbuild@^0.11.6:
-  version "0.11.6"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.11.6.tgz#20961309c4cfed00b71027e18806150358d0cbb0"
-  integrity sha512-L+nKW9ftVS/N2CVJMR9YmXHbkm+vHzlNYuo09rzipQhF7dYNvRLfWoEPSDRTl10and4owFBV9rJ2CTFNtLIOiw==
-
 esbuild@^0.8.34:
   version "0.8.43"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.8.43.tgz#19d79f8c6d1cc6dadd50942057a5aff906a1ecf2"
   integrity sha512-ZVE2CpootS4jtnfV0bbtJdgRsHEXcMP0P7ZXGfTmNzzhBr2e5ag7Vp3ry0jmw8zduJz4iHzxg4m5jtPxWERz1w==
+
+esbuild@^0.9.3:
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.9.7.tgz#ea0d639cbe4b88ec25fbed4d6ff00c8d788ef70b"
+  integrity sha512-VtUf6aQ89VTmMLKrWHYG50uByMF4JQlVysb8dmg6cOgW8JnFCipmz7p+HNBl+RR3LLCuBxFGVauAe2wfnF9bLg==
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -1601,10 +1601,10 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-vite-ssr@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/vite-ssr/-/vite-ssr-0.7.1.tgz#34e97eafd4ff008a8d072ddf64c6dc381fcca6bb"
-  integrity sha512-9stCJ8/79UOn18PjFhhoVNhICqRyriBFJPHc1BAxyLjGcN//xjdk0Pc0pxztr2gEPSh2dn1gDsDVBbdUJ6YubQ==
+vite-ssr@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/vite-ssr/-/vite-ssr-0.8.0.tgz#1c45b5c1e3321c827eee38e22ce46ee9c715dcf1"
+  integrity sha512-ALJQLGWEAhqryALUCLQo5TXRgnWy1q/zPeRT5MFBcxeND84ReJ0Z+GEl4jHh0N02hPvdZghJh3Jtkuv8RxbWKQ==
   dependencies:
     "@rollup/plugin-replace" "^2.3.3"
     "@vue/server-renderer" "^3.0.0"
@@ -1625,7 +1625,7 @@ vite@^2.0.0:
     fsevents "~2.3.1"
 
 "vitedge@file:../../src":
-  version "0.10.4"
+  version "0.10.5"
   dependencies:
     "@cloudflare/kv-asset-handler" "^0.1.1"
     "@rollup/plugin-commonjs" "^18.0.0"
@@ -1633,13 +1633,13 @@ vite@^2.0.0:
     "@rollup/plugin-node-resolve" "^11.2.1"
     "@rollup/plugin-replace" "^2.4.2"
     "@rollup/plugin-virtual" "^2.0.3"
-    esbuild "^0.11.6"
+    esbuild "^0.9.3"
     fast-glob "^3.2.5"
     multienv-loader "^1.2.0"
     node-fetch "^2.6.1"
     rollup "^2.44.0"
     rollup-plugin-esbuild "^3.0.2"
-    vite-ssr "0.7.1"
+    vite-ssr "0.8.0"
 
 vscode-languageserver-textdocument@^1.0.1:
   version "1.0.1"

--- a/src/dev/middleware.js
+++ b/src/dev/middleware.js
@@ -69,7 +69,7 @@ async function handleFunctionRequest(
       if (endpointMeta.handler) {
         const fetchRequest = await nodeToFetchRequest(req)
 
-        const { data, options = {} } = await safeHandler(() =>
+        const { data, ...options } = await safeHandler(() =>
           endpointMeta.handler({
             ...(extra || {}),
             request: fetchRequest,

--- a/src/dev/middleware.js
+++ b/src/dev/middleware.js
@@ -232,11 +232,23 @@ export async function getRenderContext({
     try {
       const res = await fetch(url.toString(), {
         method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
+        redirect: 'manual', // Relay redirects to make the browser change URL
+        headers: { 'content-type': 'application/json; charset=utf-8' },
       })
 
-      const initialState = await res.json()
-      return { initialState }
+      if (res.status >= 300 && res.status < 400) {
+        const headers = {}
+
+        for (const [key, value] of res.headers.entries()) {
+          headers[key] = value
+        }
+
+        // Returning a response like this will skip rendering
+        return { status: res.status, headers }
+      }
+
+      const data = await res.json()
+      return { initialState: data, propsStatusCode: res.status }
     } catch (error) {
       console.log(`Could not get page props for route "${propsRoute.name}"`)
       console.error(error)

--- a/src/dev/middleware.js
+++ b/src/dev/middleware.js
@@ -1,3 +1,4 @@
+import { loadEnv } from '../utils/env.js'
 import { promises as fs } from 'fs'
 import projectConfig from '../config.cjs'
 
@@ -49,12 +50,7 @@ async function polyfillWebAPIs() {
 async function prepareEnvironment() {
   await polyfillWebAPIs()
 
-  const { loadEnv } = await import('../utils/env.js')
-
-  loadEnv({
-    mode: process.env.NODE_ENV || 'development',
-    dry: false,
-  })
+  loadEnv({ dry: false })
 }
 
 async function handleFunctionRequest(

--- a/src/errors.d.ts
+++ b/src/errors.d.ts
@@ -21,7 +21,7 @@ declare module 'vitedge/errors' {
   export const UnauthorizedError: ExtendedError
   export const ForbiddenError: ExtendedError
   export const NotFoundError: ExtendedError
-  export const MethoNotAllowedError: ExtendedError
+  export const MethodNotAllowedError: ExtendedError
   export const UnknownError: ExtendedError
   export const ExternalServiceError: ExtendedError
   // export const setErrorTransformer: (

--- a/src/errors.d.ts
+++ b/src/errors.d.ts
@@ -24,4 +24,7 @@ declare module 'vitedge/errors' {
   export const MethoNotAllowedError: ExtendedError
   export const UnknownError: ExtendedError
   export const ExternalServiceError: ExtendedError
+  // export const setErrorTransformer: (
+  //   fn: (error: Error | ExtendedError) => any
+  // ) => void
 }

--- a/src/errors.d.ts
+++ b/src/errors.d.ts
@@ -1,0 +1,27 @@
+declare module 'vitedge/errors' {
+  interface ExtendedErrorInstance<T> extends Error {
+    status: number
+    name: string
+    details: T
+  }
+
+  interface ExtendedError<T = any> {
+    new (message: string, details?: T): ExtendedErrorInstance<T>
+  }
+
+  export const RestError: {
+    new (
+      message: string,
+      status: number,
+      details?: any
+    ): ExtendedErrorInstance<any>
+  }
+
+  export const BadRequestError: ExtendedError
+  export const UnauthorizedError: ExtendedError
+  export const ForbiddenError: ExtendedError
+  export const NotFoundError: ExtendedError
+  export const MethoNotAllowedError: ExtendedError
+  export const UnknownError: ExtendedError
+  export const ExternalServiceError: ExtendedError
+}

--- a/src/errors.js
+++ b/src/errors.js
@@ -22,8 +22,7 @@ export async function safeHandler(fn) {
     return await fn()
   } catch (error) {
     const data = transformError(error)
-    const options = { status: error.status || 500 }
-    return { data, options }
+    return { data, status: error.status || 500 }
   }
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,3 +1,32 @@
+const isDev = process.env.NODE_ENV === 'development'
+
+let transformError = (error) => ({
+  error: {
+    status: error.status || 500,
+    message: error.message,
+    title: error.name,
+    details: error.details,
+    stack: isDev ? error.stack : undefined,
+  },
+})
+
+export function setErrorTransformer(fn) {
+  // TODO rethink this so it doesn't need
+  // to be repeated in front and back ends.
+  // E.g. Expose it from entry-server.
+  transformError = fn
+}
+
+export async function safeHandler(fn) {
+  try {
+    return await fn()
+  } catch (error) {
+    const data = transformError(error)
+    const options = { status: error.status || 500 }
+    return { data, options }
+  }
+}
+
 export class RestError extends Error {
   constructor(message, status, details) {
     super(message)

--- a/src/errors.js
+++ b/src/errors.js
@@ -64,7 +64,7 @@ export class NotFoundError extends RestError {
   }
 }
 
-export class MethoNotAllowedError extends RestError {
+export class MethodNotAllowedError extends RestError {
   constructor(message, details) {
     super(message, 405, details)
   }

--- a/src/errors.js
+++ b/src/errors.js
@@ -19,7 +19,12 @@ export function setErrorTransformer(fn) {
 
 export async function safeHandler(fn) {
   try {
-    return await fn()
+    const result = await fn()
+    if (!result.status) {
+      result.status = 200
+    }
+
+    return result
   } catch (error) {
     const data = transformError(error)
     return { data, status: error.status || 500 }

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,54 @@
+export class RestError extends Error {
+  constructor(message, status, details) {
+    super(message)
+    this.name = this.constructor.name
+    this.status = status
+    this.details = details
+  }
+
+  toJSON() {
+    return JSON.stringify(transformError(this))
+  }
+}
+
+export class BadRequestError extends RestError {
+  constructor(message, details) {
+    super(message, 400, details)
+  }
+}
+
+export class UnauthorizedError extends RestError {
+  constructor(message, details) {
+    super(message, 401, details)
+  }
+}
+
+export class ForbiddenError extends RestError {
+  constructor(message, details) {
+    super(message, 403, details)
+  }
+}
+
+export class NotFoundError extends RestError {
+  constructor(message, details) {
+    super(message, 404, details)
+  }
+}
+
+export class MethoNotAllowedError extends RestError {
+  constructor(message, details) {
+    super(message, 405, details)
+  }
+}
+
+export class UnknownError extends RestError {
+  constructor(message, details) {
+    super(message, 500, details)
+  }
+}
+
+export class ExternalServiceError extends RestError {
+  constructor(message, details) {
+    super(message, 503, details)
+  }
+}

--- a/src/node/api.js
+++ b/src/node/api.js
@@ -6,7 +6,7 @@ export async function handleApiRequest({ url, functions }, event) {
   const fnMeta = functions[normalizePathname(url)]
 
   if (fnMeta) {
-    const { data, options = {} } = await safeHandler(() =>
+    const { data, ...options } = await safeHandler(() =>
       fnMeta.handler({
         ...event,
         url,

--- a/src/node/api.js
+++ b/src/node/api.js
@@ -1,14 +1,17 @@
 import nodeFetch from 'node-fetch'
+import { safeHandler } from '../errors.js'
 import { getEventType, normalizePathname } from './utils.js'
 
 export async function handleApiRequest({ url, functions }, event) {
   const fnMeta = functions[normalizePathname(url)]
 
   if (fnMeta) {
-    const { data, options = {} } = await fnMeta.handler({
-      ...event,
-      url,
-    })
+    const { data, options = {} } = await safeHandler(() =>
+      fnMeta.handler({
+        ...event,
+        url,
+      })
+    )
 
     const headers = {
       'content-type': 'application/json; charset=utf-8',

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -25,14 +25,19 @@ export async function handleEvent(
     return { statusCode: 404 }
   }
 
-  const { data: pageProps, options: propsOptions } = await getPageProps(
+  const { data: pageProps, options: propsOptions = {} } = await getPageProps(
     { functions, router, url },
     event
   )
 
   // This handles SPA page props requests from the browser
   if (type === 'props') {
-    return { ...propsOptions, body: JSON.stringify(pageProps || {}) }
+    return {
+      statusCode: propsOptions.status,
+      statusMessage: propsOptions.statusText,
+      ...propsOptions,
+      body: JSON.stringify(pageProps || {}),
+    }
   }
 
   globalThis.fetch = createLocalFetch({ url, functions })

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -30,12 +30,15 @@ export async function handleEvent(
     event
   )
 
+  const status = propsOptions.status
+  const isRedirect = status >= 300 && status < 400
   // This handles SPA page props requests from the browser
-  if (type === 'props') {
+  if (type === 'props' || isRedirect) {
     return {
-      statusCode: propsOptions.status,
+      statusCode: status,
       statusMessage: propsOptions.statusText,
       ...propsOptions,
+      status,
       body: JSON.stringify(pageProps || {}),
     }
   }
@@ -46,6 +49,7 @@ export async function handleEvent(
   const { html, ...extra } = await router.render(url, {
     ...event,
     initialState: pageProps,
+    propsStatusCode: propsOptions.status,
     manifest,
     preload,
   })

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -30,10 +30,13 @@ export async function handleEvent(
     event
   )
 
-  const status = propsOptions.status
+  let status = propsOptions.status
   const isRedirect = status >= 300 && status < 400
   // This handles SPA page props requests from the browser
   if (type === 'props' || isRedirect) {
+    // Mock status when this is a props request to bypass Fetch opaque responses
+    status = type === 'props' && isRedirect ? 299 : status
+
     return {
       statusCode: status,
       statusMessage: propsOptions.statusText,

--- a/src/node/props.js
+++ b/src/node/props.js
@@ -5,7 +5,7 @@ export async function getPageProps({ functions, router, url }, event) {
   const fnMeta = functions[propsGetter]
 
   if (fnMeta) {
-    const { data, options } = await safeHandler(() =>
+    const { data, ...options } = await safeHandler(() =>
       fnMeta.handler({
         ...event,
         ...extra,

--- a/src/node/props.js
+++ b/src/node/props.js
@@ -1,13 +1,17 @@
+import { safeHandler } from '../errors.js'
+
 export async function getPageProps({ functions, router, url }, event) {
   const { propsGetter, ...extra } = router.resolve(url.pathname) || {}
   const fnMeta = functions[propsGetter]
 
   if (fnMeta) {
-    const { data, options } = await fnMeta.handler({
-      ...event,
-      ...extra,
-      url,
-    })
+    const { data, options } = await safeHandler(() =>
+      fnMeta.handler({
+        ...event,
+        ...extra,
+        url,
+      })
+    )
 
     return { data, options }
   } else {

--- a/src/package.json
+++ b/src/package.json
@@ -79,6 +79,6 @@
     "node-fetch": "^2.6.1",
     "rollup": "^2.44.0",
     "rollup-plugin-esbuild": "^3.0.2",
-    "vite-ssr": "0.7.1"
+    "vite-ssr": "0.8.0"
   }
 }

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -2,6 +2,8 @@ import path from 'path'
 import multienv from 'multienv-loader'
 import config from '../config.cjs'
 
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+
 export function loadEnv({ mode = 'development', dry = true } = {}) {
   const { rootDir } = config.getProjectInfo()
   return multienv.load({

--- a/src/worker/api.js
+++ b/src/worker/api.js
@@ -66,7 +66,7 @@ export async function handleApiRequest(event) {
     const { handler, options: staticOptions } = resolvedFn
 
     const { url, query } = parseQuerystring(event)
-    const { data, options: dynamicOptions } = await safeHandler(() =>
+    const { data, ...dynamicOptions } = await safeHandler(() =>
       handler({
         event,
         request: event.request,
@@ -76,7 +76,7 @@ export async function handleApiRequest(event) {
       })
     )
 
-    const options = Object.assign({}, staticOptions || {}, dynamicOptions || {})
+    const options = Object.assign({}, staticOptions || {}, dynamicOptions)
 
     const response = buildApiResponse(data, options)
 

--- a/src/worker/api.js
+++ b/src/worker/api.js
@@ -4,6 +4,7 @@ import {
   resolveFnsEndpoint,
 } from './utils'
 import { getCachedResponse, setCachedResponse } from './cache'
+import { safeHandler } from '../errors'
 
 const API_PREFIX = '/api'
 
@@ -65,24 +66,28 @@ export async function handleApiRequest(event) {
     const { handler, options: staticOptions } = resolvedFn
 
     const { url, query } = parseQuerystring(event)
-    const { data, options: dynamicOptions } = await handler({
-      event,
-      request: event.request,
-      headers: event.request.headers,
-      url,
-      query,
-    })
+    const { data, options: dynamicOptions } = await safeHandler(() =>
+      handler({
+        event,
+        request: event.request,
+        headers: event.request.headers,
+        url,
+        query,
+      })
+    )
 
     const options = Object.assign({}, staticOptions || {}, dynamicOptions || {})
 
     const response = buildApiResponse(data, options)
 
-    setCachedResponse(
-      event,
-      response,
-      cacheKey,
-      ((options && options.cache) || {}).api
-    )
+    if ((options.status || 0) < 400) {
+      setCachedResponse(
+        event,
+        response,
+        cacheKey,
+        ((options && options.cache) || {}).api
+      )
+    }
 
     return response
   }

--- a/src/worker/props.js
+++ b/src/worker/props.js
@@ -98,9 +98,10 @@ export async function getPageProps(event) {
 export async function handlePropsRequest(event) {
   const page = await getPageProps(event)
 
-  if (page) {
-    return page.response
+  if (page.response.status >= 300 && page.response.status < 400) {
+    // Mock redirect status on props request to bypass Fetch opaque responses
+    return new Response(page.response.body, { ...page.response, status: 299 })
   }
 
-  return createNotFoundResponse()
+  return page.response
 }

--- a/src/worker/props.js
+++ b/src/worker/props.js
@@ -72,7 +72,7 @@ export async function getPageProps(event) {
     }
   }
 
-  const { data, options: dynamicOptions } = await safeHandler(() =>
+  const { data, ...dynamicOptions } = await safeHandler(() =>
     handler({
       ...(route || {}),
       event,
@@ -81,7 +81,7 @@ export async function getPageProps(event) {
     })
   )
 
-  const options = Object.assign({}, staticOptions || {}, dynamicOptions || {})
+  const options = Object.assign({}, staticOptions || {}, dynamicOptions)
 
   const response = buildPropsResponse(data, options)
 

--- a/src/worker/props.js
+++ b/src/worker/props.js
@@ -54,13 +54,16 @@ function getCacheKey(event) {
 }
 
 export async function getPageProps(event) {
-  const propsRoute = resolvePropsRoute(event.request.url)
+  const { handler, options: staticOptions, route } =
+    resolvePropsRoute(event.request.url) || {}
 
-  if (!propsRoute) {
-    return null
+  if (!handler) {
+    return {
+      response: createNotFoundResponse(),
+      options: staticOptions,
+    }
   }
 
-  const { handler, options: staticOptions, route } = propsRoute
   const cacheOption =
     staticOptions && staticOptions.cache && staticOptions.cache.api
   const cacheKey = cacheOption && getCacheKey(event)

--- a/src/worker/utils.js
+++ b/src/worker/utils.js
@@ -17,5 +17,5 @@ export function createResponse(body, params = {}) {
 }
 
 export function createNotFoundResponse() {
-  return createResponse('Not found', { status: 404 })
+  return createResponse(null, { status: 404 })
 }

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -573,10 +573,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-vite-ssr@0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/vite-ssr/-/vite-ssr-0.7.1.tgz#34e97eafd4ff008a8d072ddf64c6dc381fcca6bb"
-  integrity sha512-9stCJ8/79UOn18PjFhhoVNhICqRyriBFJPHc1BAxyLjGcN//xjdk0Pc0pxztr2gEPSh2dn1gDsDVBbdUJ6YubQ==
+vite-ssr@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/vite-ssr/-/vite-ssr-0.8.0.tgz#1c45b5c1e3321c827eee38e22ce46ee9c715dcf1"
+  integrity sha512-ALJQLGWEAhqryALUCLQo5TXRgnWy1q/zPeRT5MFBcxeND84ReJ0Z+GEl4jHh0N02hPvdZghJh3Jtkuv8RxbWKQ==
   dependencies:
     "@rollup/plugin-replace" "^2.3.3"
     "@vue/server-renderer" "^3.0.0"


### PR DESCRIPTION
@subhendukundu @huygn Hello! If you have some time, would you give me some feedback about this error handling feature?

Basically, this enables throwing errors in API or Props handlers and have Vitedge return a well-formed JSON payload.

Something like this:

```js
// props or api handler
export default ({
  handler(...) {
     if (condition) {
       throw new BadRequestError('My error message', { code: 'malformed' })
     }

     return { data: {} }
  }
})
```

The payload returned would be:

```js
{
  error: {
    status: 400,
    message: 'My error message',
    details: { code: 'malformed' }
  }
}
```

This error format can be modified in user-land, but I haven't decided yet exactly how (for now there is a `setErrorTransformer` function to do this, but needs to be refined). New errors can also be created by just extending `RestError` class.

--

With this basically a page component will get an `error` prop that contains status, message and details, so it can render anything or redirect to another route.

Thoughts? Do you think it's useful like this?
Thanks!