### PR TITLE
fix: handleEvent errors if options is not sent as {}

### DIFF
--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -19,7 +19,7 @@ export async function handleEvent(
     didRequestProps,
     willRequestRender,
     didRequestRender,
-  }
+  } = {}
 ) {
   // --- PREFLIGHT REQUESTS
   if (event.request.method === 'OPTIONS') {


### PR DESCRIPTION
When following the example in https://github.com/frandiox/vitedge/blob/master/docs/usage.md, I get the following error: 

```
Uncaught (in promise)
TypeError: Cannot destructure property 'http2ServerPush' of 'undefined' as it is undefined.
    at T (worker.js:30:9231)
    at worker.js:30:10550
Uncaught (in response)
TypeError: Cannot destructure property 'http2ServerPush' of 'undefined' as it is undefined.
```

Either the example should be updated, or fallback to `{}` if the user doesn't pass in anything for options.
