### PR TITLE
Avoid 404 for pages without props handler (fix #66)

### DIFF
--- a/examples/vue/src/App.vue
+++ b/examples/vue/src/App.vue
@@ -5,6 +5,7 @@
     <RouterLink to="/">Go to Home</RouterLink>
     <RouterLink to="/a">Go to A</RouterLink>
     <RouterLink to="/b">Go to B</RouterLink>
+    <RouterLink to="/c">Go to C</RouterLink>
   </nav>
   <h1>Below is the currently rendered route:</h1>
 

--- a/examples/vue/src/pages/PageC.vue
+++ b/examples/vue/src/pages/PageC.vue
@@ -1,0 +1,3 @@
+<template>
+  <h1>Page C - Fully static</h1>
+</template>

--- a/examples/vue/src/routes.ts
+++ b/examples/vue/src/routes.ts
@@ -24,6 +24,11 @@ export default [
     },
   },
   {
+    path: '/c',
+    component: () => import('./pages/PageC.vue'),
+    name: 'c',
+  },
+  {
     path: '/example/:resource',
     component: () => import('./pages/PageB.vue'),
     name: 'example',

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -44,7 +44,7 @@ export async function handleEvent(
   // This handles SPA page props requests from the browser
   if (type === 'props' || isRedirecting) {
     // Mock status when this is a props request to bypass Fetch opaque responses
-    const status = type === 'props' && isRedirecting ? 299 : propsOptions.status
+    const status = type === 'props' && isRedirecting ? 299 : propsOptions.status || 404
 
     return {
       statusCode: status,

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -49,7 +49,7 @@ export async function handleEvent(
     const { url, query } = parseQuerystring(event)
 
     willRequestProps && (await willRequestProps({ event, url, query }))
-    const response = await handlePropsRequest(event) || createNotFoundResponse()
+    const response = await handlePropsRequest(event)
 
     return (
       (didRequestProps &&

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -49,7 +49,7 @@ export async function handleEvent(
     const { url, query } = parseQuerystring(event)
 
     willRequestProps && (await willRequestProps({ event, url, query }))
-    const response = await handlePropsRequest(event)
+    const response = await handlePropsRequest(event) || createNotFoundResponse()
 
     return (
       (didRequestProps &&

--- a/src/worker/props.js
+++ b/src/worker/props.js
@@ -98,12 +98,12 @@ export async function getPageProps(event) {
 }
 
 export async function handlePropsRequest(event) {
-  const page = await getPageProps(event)
+  const { response = createNotFoundResponse() } = await getPageProps(event)
 
-  if (page.response.status >= 300 && page.response.status < 400) {
+  if (response.status >= 300 && response.status < 400) {
     // Mock redirect status on props request to bypass Fetch opaque responses
-    return new Response(page.response.body, { ...page.response, status: 299 })
+    return new Response(response.body, { ...response, status: 299 })
   }
 
-  return page.response
+  return response
 }

--- a/src/worker/props.js
+++ b/src/worker/props.js
@@ -61,7 +61,7 @@ export async function getPageProps(event) {
 
   if (!handler) {
     return {
-      response: createNotFoundResponse(),
+      response: undefined,
       options: staticOptions || {},
     }
   }

--- a/src/worker/render.js
+++ b/src/worker/render.js
@@ -12,7 +12,7 @@ export async function handleViewRendering(event, { http2ServerPush }) {
     return cachedResponse
   }
 
-  const [{ response: propsResponse, options: propsOptions = {} }, manifest] =
+  const [{ response: propsResponse = {}, options: propsOptions = {} }, manifest] =
     await Promise.all([getPageProps(event), getSsrManifest(event)])
 
   if (isRedirect(propsResponse)) {


### PR DESCRIPTION
As stated in the title closes #66 
