### PR TITLE
fix(plugin): pass containerId opt to viteSsr

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -10,6 +10,7 @@ export default (options = {}) => {
     viteSSR({
       plugin: pluginName,
       getRenderContext,
+      containerId: options.containerId,
       excludeSsrComponents: options.excludeSsrComponents,
     }),
     {


### PR DESCRIPTION
Right now `containerId` is not passed to vite-ssr

ref: https://github.com/frandiox/vite-ssr/blob/217e6102183065820be69769a4667e1e12e4813d/src/plugin.ts#L40