### PR TITLE
fix(plugin): add transformState declaration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,9 +1,9 @@
-import type { SharedContext } from 'vite-ssr/utils/types'
+import type { SharedContext, SharedOptions } from 'vite-ssr/utils/types'
 
 declare module 'vitedge' {
   const handler: (
     App: any,
-    options: {
+    options: Pick<SharedOptions, 'transformState'> & {
       routes: Array<Record<string, any>>
       base?: (params: { url: URL }) => string
       pageProps?: { passToPage: boolean }


### PR DESCRIPTION
Typescript declaration for viteSSR's transformState was missing.

Additionally, could you please publish a new release. This fix and the last fix with the `containerId` are kind of important.