### PR TITLE
fix: update typings for useContext to be callable

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,7 +29,7 @@ declare module 'vitedge' {
   export default handler
 
   export const ClientOnly: any
-  export const useContext: Omit<SharedContext, 'request' | 'response'>
+  export const useContext: () => Omit<SharedContext, 'request' | 'response'>
   export const usePageProps: () => Record<string, any>
 }
 


### PR DESCRIPTION
Hello,

There is a Typescript definition issue when using: `const { request } = useContext()`. We get the following error:
```
This expression is not callable.
  Type 'Omit<SharedContext, "request" | "response">' has no call signatures.
```

This small PR fix this error by making `useContext` callable.