### PR TITLE
fix: preview server url for vite 3.x

### DIFF
--- a/src/build/preview.js
+++ b/src/build/preview.js
@@ -75,8 +75,14 @@ export default async function preview({
         )
 
         const { printHttpServerUrls } = await import('vite')
+        const vitePkg = requireJson('vite/package.json')
+        const protocol = https ? 'https' : 'http'
 
-        if (printHttpServerUrls) {
+        if (vitePkg.version.startsWith('3')) {
+          // Vite 3.x does not expose utilities
+          console.log(chalk.bold(chalk.white('➜  Local: ')), chalk.cyan(`${protocol}://localhost:${port}/`));
+        }
+        else if (printHttpServerUrls) {
           // Vite 2.6.x exposes this function
           printHttpServerUrls(
             {
@@ -91,7 +97,6 @@ export default async function preview({
         } else {
           // Older versions of Vite
           const viteInternals = await getViteInternals()
-          const protocol = https ? 'https' : 'http'
           viteInternals.printServerUrls(
             viteInternals.resolveHostname(host),
             protocol,
@@ -103,8 +108,8 @@ export default async function preview({
 
         mf.log.log(
           '\n -- Preview mode' +
-            (buildWatch ? '. Waiting for updates' : '') +
-            '\n'
+          (buildWatch ? '. Waiting for updates' : '') +
+          '\n'
         )
       })
     })


### PR DESCRIPTION

Vite 3.x does not export utilities to print server URL and the Vite internal has changed. As a result, the preview crashes while trying to print server info. This PR fixes the issues by printing server info directly from Vitedge keeping the current implementation for older versions.