### PR TITLE
Remove reference to archived discord server in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ See [live demo](https://vitessedge.zable.workers.dev/), and [Vue](https://github
 
 See [docs](https://vitedge.js.org).
 
-To talk about Vitedge, join [ViteLand Discord](https://discord.gg/taRZdpzHhR) and check `#vitedge` channel or use [GitHub's Discussions](https://github.com/frandiox/vitedge/discussions).
+To talk about Vitedge, you can use [GitHub's Discussions](https://github.com/frandiox/vitedge/discussions).
 
 ## Starters
 


### PR DESCRIPTION
Just found this project and joined the Discord to ask about it, but it looks like the referenced server is archived and it was slightly disappointing so want to avoid that path for others.

Are there still plans to further develop this? If not it may be worth archiving. I found this via [vite-ssr](https://github.com/frandiox/vite-ssr)'s readme, though it looks like that project is somewhat stale as well.